### PR TITLE
fix bug in seed logic that did not remove blabs

### DIFF
--- a/config/seeds.js
+++ b/config/seeds.js
@@ -26,28 +26,28 @@ User.remove({})
 
 .then(function() {
   console.log("Removing blabs…");
-  Blab.remove({});
-})
+  Blab.remove({})
+  .then(function() {
+    process.stdout.write("Creating blabs: ");
+    return Blab.create(definedBlabs(users));
+  })
 
-.then(function() {
-  process.stdout.write("Creating blabs: ");
-  return Blab.create(definedBlabs(users));
-})
+  .then(function(blabs) {
+    console.log("Database seeded with " + blabs.length  + " blabs.");
+  })
 
-.then(function(blabs) {
-  console.log("Database seeded with " + blabs.length  + " blabs.");
-})
+  // Catch and log any errors along the chain.
+  .catch(function(err) {
+    console.log("Error:", err);
+  })
 
-// Catch and log any errors along the chain.
-.catch(function(err) {
-  console.log("Error:", err);
-})
+  // Finish the chain.
+  .then(
+    closeMongoConnection, // when the chain is successful…
+    closeMongoConnection  // when the chain has failed…
+  )
+});
 
-// Finish the chain.
-.then(
-  closeMongoConnection, // when the chain is successful…
-  closeMongoConnection  // when the chain has failed…
-);
 
 
 function closeMongoConnection() {


### PR DESCRIPTION
properly nested promises *after* mongodb Blab.remove({}) query

**BEFORE (note blabs document count increasing after `npm run seed`):**
![before](https://cloud.githubusercontent.com/assets/4521569/13766877/fe48e200-ea22-11e5-836e-ad99da5531eb.png)

**AFTER (note blabs document count constant after `npm run seed`):**
![before](https://cloud.githubusercontent.com/assets/4521569/13766885/086a7c44-ea23-11e5-810c-9153483e010d.png)